### PR TITLE
chore: refresh GitHub Actions workflow dependencies

### DIFF
--- a/.github/workflows/implementation-gates.yml
+++ b/.github/workflows/implementation-gates.yml
@@ -28,7 +28,7 @@ jobs:
       has_android: ${{ steps.detect.outputs.has_android }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Read CI gate activation config
         id: read
@@ -77,10 +77,10 @@ jobs:
     if: ${{ needs.gate-config.outputs.node_static == 'true' && needs.gate-config.outputs.has_node_root == 'true' }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 22
           cache: npm
@@ -91,7 +91,7 @@ jobs:
 
       - name: Upload Node coverage
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: node-coverage
           path: |
@@ -106,10 +106,10 @@ jobs:
     if: ${{ needs.gate-config.outputs.node_integration == 'true' && needs.gate-config.outputs.has_node_packages == 'true' }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 22
           cache: npm
@@ -125,17 +125,17 @@ jobs:
     if: ${{ needs.gate-config.outputs.android_static == 'true' && needs.gate-config.outputs.has_android == 'true' }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Java
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: temurin
           java-version: 21
           cache: gradle
 
       - name: Validate Gradle wrapper
-        uses: gradle/actions/wrapper-validation@v4
+        uses: gradle/actions/wrapper-validation@v6
         with:
           min-wrapper-count: 1
 
@@ -144,7 +144,7 @@ jobs:
 
       - name: Upload Android unit test reports
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: android-unit-test-reports
           path: |
@@ -159,10 +159,10 @@ jobs:
     if: ${{ needs.gate-config.outputs.android_instrumented == 'true' && needs.gate-config.outputs.has_android == 'true' }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Java
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: temurin
           java-version: 21
@@ -179,7 +179,7 @@ jobs:
 
       - name: Upload Android instrumentation artifacts
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: android-instrumented-artifacts
           path: |

--- a/.github/workflows/nightly-system-gates.yml
+++ b/.github/workflows/nightly-system-gates.yml
@@ -22,7 +22,7 @@ jobs:
       has_android: ${{ steps.detect.outputs.has_android }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Read CI gate activation config
         id: read
@@ -58,10 +58,10 @@ jobs:
     if: ${{ needs.gate-config.outputs.nightly_system == 'true' && needs.gate-config.outputs.has_node_root == 'true' }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 22
           cache: npm
@@ -77,10 +77,10 @@ jobs:
     if: ${{ needs.gate-config.outputs.nightly_system == 'true' && needs.gate-config.outputs.has_android == 'true' }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Java
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: temurin
           java-version: 21

--- a/.github/workflows/repo-governance.yml
+++ b/.github/workflows/repo-governance.yml
@@ -28,7 +28,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Validate PR review evidence
         env:
@@ -40,7 +40,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Validate spec-first repo structure
         run: bash scripts/ci/validate_spec_repo.sh
@@ -50,10 +50,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 22
 
@@ -80,7 +80,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Install shellcheck
         run: sudo apt-get update && sudo apt-get install --yes shellcheck
@@ -97,10 +97,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version: "1.24"
 

--- a/.github/workflows/security-supply-chain.yml
+++ b/.github/workflows/security-supply-chain.yml
@@ -30,7 +30,7 @@ jobs:
       has_android_kotlin: ${{ steps.detect.outputs.has_android_kotlin }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Read CI gate activation config
         id: read
@@ -77,7 +77,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Dependency review
         uses: actions/dependency-review-action@v4
@@ -89,18 +89,18 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v3
+        uses: github/codeql-action/init@v4
         with:
           languages: javascript-typescript
 
       - name: Autobuild
-        uses: github/codeql-action/autobuild@v3
+        uses: github/codeql-action/autobuild@v4
 
       - name: Analyze
-        uses: github/codeql-action/analyze@v3
+        uses: github/codeql-action/analyze@v4
 
   codeql-kotlin:
     name: CodeQL Kotlin
@@ -109,15 +109,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v3
+        uses: github/codeql-action/init@v4
         with:
           languages: kotlin
 
       - name: Autobuild
-        uses: github/codeql-action/autobuild@v3
+        uses: github/codeql-action/autobuild@v4
 
       - name: Analyze
-        uses: github/codeql-action/analyze@v3
+        uses: github/codeql-action/analyze@v4


### PR DESCRIPTION
# Summary

## Change Summary

- What changed: refresh GitHub Actions dependencies across the repo workflows, including `actions/checkout`, `actions/setup-node`, `actions/setup-java`, `actions/setup-go`, `actions/upload-artifact`, `gradle/actions/wrapper-validation`, and `github/codeql-action`
- Why now: the previous Dependabot workflow update PRs were valuable maintenance work but became unserviceable once their bot branches were closed; this PR rebuilds the same updates in a normal branch so they can go through the standard repo process
- Impacted areas: `.github/workflows/implementation-gates.yml`, `.github/workflows/nightly-system-gates.yml`, `.github/workflows/repo-governance.yml`, `.github/workflows/security-supply-chain.yml`
- Out of scope: no workflow logic, no gate activation settings, no application code, no package dependency updates

## Verification

- Local checks: `npx -y prettier --check .github/workflows/*.yml`; `GO111MODULE=on go install github.com/rhysd/actionlint/cmd/actionlint@latest && "$(go env GOPATH)/bin/actionlint"`
- CI expectations: repo governance and workflow validation should pass; implementation gates should remain behaviorally unchanged because only action versions moved
- Risks or follow-ups: major-version action bumps can surface upstream behavioral changes only in GitHub-hosted execution, so CI results remain the final authority before merge

## Linked Work

- Issue: maintenance
- OpenSpec change: `n/a`
- Requirements: `n/a`
- Test plan IDs: `n/a`

## Agent Review

- Record review evidence for the current PR head. If new commits are pushed, rerun reviewer agents and update this section.
- Treat linked reviewer comments as immutable evidence. If a reviewer result changes, post a new PR comment and update the links below instead of editing a linked comment.
- If you do change linked reviewer comments or links, also edit the PR body or rerun `Repo Governance` so the evidence check reevaluates them.
- Reviewer agents used: `workflow-reviewer, security-reviewer`
- Reviewed head SHA: `51ff44ae7959e2dc166f76d9e09e5f54f3491cbf`
- Review evidence: `https://github.com/DankerMu/IMbot/pull/53#issuecomment-4150120957, https://github.com/DankerMu/IMbot/pull/53#issuecomment-4150120973`
- Key findings addressed: `No material findings were raised. Residual risk is limited to upstream major-version behavior changes in GitHub-hosted runners, so merge remains contingent on green CI.`

## Checklist

- [x] Scope still matches `docs/PRD.md`
- [x] Engineering spec and UI spec stay aligned with the change
- [x] OpenSpec ownership is explicit or updated in the same PR
- [x] Added or updated the required tests for the affected requirement
- [x] At least two reviewer agents completed cross-review, posted readable PR comments, and the `Agent Review` section matches the current PR head
- [x] The PR has no unresolved conversations before merge
- [x] CI gate activation was reviewed if this PR introduces a new package, test layer, or release path

## Notes

- This PR functionally replaces the closed Dependabot PRs `#50` and `#51` with one human-owned maintenance PR.
