### PR TITLE
feat(android): idle multi-turn conversation UI

### DIFF
--- a/packages/android/app/src/main/kotlin/com/imbot/android/network/RelayHttpClient.kt
+++ b/packages/android/app/src/main/kotlin/com/imbot/android/network/RelayHttpClient.kt
@@ -616,6 +616,39 @@ open class RelayHttpClient
                 }
             }
 
+        open suspend fun completeSession(
+            relayUrl: String,
+            token: String,
+            sessionId: String,
+        ): Result<RelaySession> =
+            runCatching {
+                withContext(Dispatchers.IO) {
+                    val request =
+                        Request.Builder()
+                            .url(
+                                requireRelayBaseUrl(relayUrl)
+                                    .newBuilder()
+                                    .addPathSegments("v1/sessions")
+                                    .addPathSegment(sessionId)
+                                    .addPathSegment("complete")
+                                    .build(),
+                            )
+                            .header("Authorization", "Bearer $token")
+                            .post("{}".toRequestBody(JSON_MEDIA_TYPE))
+                            .build()
+
+                    okHttpClient.newCall(request).await().use { response ->
+                        val bodyText = response.body?.string().orEmpty()
+                        if (!response.isSuccessful) {
+                            throw relayFailure(response, bodyText, "Complete session")
+                        }
+
+                        val root = bodyText.toJsonObjectOrNull() ?: error("Relay returned malformed JSON")
+                        root.requireRelaySessionObject().toRelaySession()
+                    }
+                }
+            }
+
         private companion object {
             val JSON_MEDIA_TYPE = "application/json; charset=utf-8".toMediaType()
             const val DEFAULT_SESSION_PAGE_LIMIT = 200
@@ -770,7 +803,7 @@ private fun relayFailure(
     )
 }
 
-private fun JSONObject.toRelaySession(): RelaySession {
+internal fun JSONObject.toRelaySession(): RelaySession {
     val id = optString("id")
     require(id.isNotBlank()) { "Relay response is missing session.id" }
 

--- a/packages/android/app/src/main/kotlin/com/imbot/android/ui/components/StatusIndicator.kt
+++ b/packages/android/app/src/main/kotlin/com/imbot/android/ui/components/StatusIndicator.kt
@@ -124,6 +124,7 @@ fun StatusIndicator(
 private fun statusLabel(status: String): String =
     when (status) {
         "running" -> "运行中"
+        "idle" -> "空闲"
         "queued" -> "排队中"
         "completed" -> "已完成"
         "failed" -> "失败"

--- a/packages/android/app/src/main/kotlin/com/imbot/android/ui/detail/DetailUtils.kt
+++ b/packages/android/app/src/main/kotlin/com/imbot/android/ui/detail/DetailUtils.kt
@@ -79,7 +79,13 @@ internal fun resumeAutoScroll(current: DetailScrollState): ScrollMutation =
         shouldScrollToBottom = true,
     )
 
-internal fun canSendToSession(status: String?): Boolean = status == "running"
+internal fun canSendToSession(status: String?): Boolean = status == "running" || status == "idle"
+
+internal fun canInputToSession(status: String?): Boolean = status == "idle"
+
+internal fun canCancelSession(status: String?): Boolean = status == "running"
+
+internal fun canCompleteSession(status: String?): Boolean = status == "idle"
 
 internal fun detailStatusColor(
     status: String,
@@ -88,7 +94,8 @@ internal fun detailStatusColor(
 
 internal fun inputPlaceholderForStatus(status: String?): String =
     when (status) {
-        "running" -> "输入消息..."
+        "running" -> "AI 正在回复..."
+        "idle" -> "继续对话..."
         "queued" -> "会话启动中，暂时无法发送"
         "completed" -> "会话已结束"
         "failed" -> "会话已失败"
@@ -103,6 +110,7 @@ internal fun messageItemKindForEventType(eventType: String): MessageItemKind? =
         "tool_call_started", "tool_call_completed" -> MessageItemKind.ToolCall
         "session_status_changed",
         "session_started",
+        "session_idle",
         "session_result",
         "session_error",
         "approval_required",
@@ -189,6 +197,7 @@ internal fun providerColor(
 internal fun statusLabel(status: String): String =
     when (status) {
         "running" -> "运行中"
+        "idle" -> "空闲"
         "queued" -> "排队中"
         "completed" -> "已完成"
         "failed" -> "失败"

--- a/packages/android/app/src/main/kotlin/com/imbot/android/ui/detail/DetailViewModel.kt
+++ b/packages/android/app/src/main/kotlin/com/imbot/android/ui/detail/DetailViewModel.kt
@@ -43,6 +43,7 @@ data class DetailUiState(
     val canSend: Boolean = false,
     val isSending: Boolean = false,
     val isCancelling: Boolean = false,
+    val isCompleting: Boolean = false,
     val isDeleting: Boolean = false,
     val scrollState: DetailScrollState = DetailScrollState(),
     val connectionBanner: ConnectionBannerUiState? = null,
@@ -195,8 +196,12 @@ class DetailViewModel
                 ).onSuccess {
                     _uiState.update { current ->
                         current.copy(
+                            session =
+                                current.session?.copy(
+                                    status = "running",
+                                ),
                             isSending = false,
-                            canSend = canSendToSession(current.session?.status),
+                            canSend = false,
                         )
                     }
                 }.onFailure { error ->
@@ -208,7 +213,7 @@ class DetailViewModel
                     _uiState.update { current ->
                         current.copy(
                             isSending = false,
-                            canSend = canSendToSession(current.session?.status),
+                            canSend = canInputToSession(current.session?.status),
                             error = error.message ?: "发送消息失败",
                         )
                     }
@@ -219,7 +224,7 @@ class DetailViewModel
         fun cancelSession() {
             val state = _uiState.value
             val session = state.session
-            val canCancel = session != null && !state.isCancelling && canSendToSession(session.status)
+            val canCancel = session != null && !state.isCancelling && canCancelSession(session.status)
             val settings = if (canCancel) requireValidSettings() else null
             if (!canCancel || session == null || settings == null) {
                 return
@@ -248,6 +253,44 @@ class DetailViewModel
                         current.copy(
                             isCancelling = false,
                             error = error.message ?: "取消会话失败",
+                        )
+                    }
+                }
+            }
+        }
+
+        fun completeSession() {
+            val state = _uiState.value
+            val session = state.session
+            val canComplete = session != null && !state.isCompleting && canCompleteSession(session.status)
+            if (!canComplete || session == null) {
+                return
+            }
+
+            val settings = requireValidSettings() ?: return
+            _uiState.update { current ->
+                current.copy(
+                    isCompleting = true,
+                )
+            }
+
+            viewModelScope.launch {
+                relayHttpClient.completeSession(
+                    relayUrl = settings.relayUrl,
+                    token = settings.token,
+                    sessionId = sessionId,
+                ).onSuccess { updatedSession ->
+                    publishSession(updatedSession)
+                    _uiState.update { current ->
+                        current.copy(
+                            isCompleting = false,
+                        )
+                    }
+                }.onFailure { error ->
+                    _uiState.update { current ->
+                        current.copy(
+                            isCompleting = false,
+                            error = error.message ?: "结束会话失败",
                         )
                     }
                 }
@@ -484,7 +527,7 @@ class DetailViewModel
             _uiState.update { current ->
                 current.copy(
                     session = session,
-                    canSend = canSendToSession(session.status) && !current.isSending,
+                    canSend = canInputToSession(session.status) && !current.isSending,
                 )
             }
         }
@@ -497,6 +540,15 @@ class DetailViewModel
                     publishSession(
                         currentSession.copy(
                             status = "running",
+                            errorMessage = currentSession.errorMessage,
+                        ),
+                    )
+                }
+
+                "session_idle" -> {
+                    publishSession(
+                        currentSession.copy(
+                            status = "idle",
                             errorMessage = currentSession.errorMessage,
                         ),
                     )

--- a/packages/android/app/src/main/kotlin/com/imbot/android/ui/detail/EventProcessor.kt
+++ b/packages/android/app/src/main/kotlin/com/imbot/android/ui/detail/EventProcessor.kt
@@ -70,6 +70,12 @@ class EventProcessor(
                     message = null,
                     seq = event.seq,
                 )
+            "session_idle" ->
+                appendStatusChange(
+                    status = "idle",
+                    message = "本轮完成，可继续对话",
+                    seq = event.seq,
+                )
             "session_result" ->
                 appendStatusChange(
                     status = event.payload.stringValue("status").orEmpty(),

--- a/packages/android/app/src/main/kotlin/com/imbot/android/ui/detail/InputBar.kt
+++ b/packages/android/app/src/main/kotlin/com/imbot/android/ui/detail/InputBar.kt
@@ -35,7 +35,8 @@ fun InputBar(
     modifier: Modifier = Modifier,
 ) {
     var draft by rememberSaveable { mutableStateOf("") }
-    val canSubmit = draft.isNotBlank() && canSend && !isSending
+    val inputEnabled = canInputToSession(status) && canSend && !isSending
+    val canSubmit = draft.isNotBlank() && inputEnabled
 
     Surface(
         modifier = modifier.fillMaxWidth(),
@@ -54,7 +55,7 @@ fun InputBar(
                 value = draft,
                 onValueChange = { draft = it },
                 modifier = Modifier.weight(1f),
-                enabled = canSend && !isSending,
+                enabled = inputEnabled,
                 minLines = 1,
                 maxLines = 4,
                 placeholder = {

--- a/packages/android/app/src/main/kotlin/com/imbot/android/ui/detail/SessionDetailScreen.kt
+++ b/packages/android/app/src/main/kotlin/com/imbot/android/ui/detail/SessionDetailScreen.kt
@@ -24,6 +24,7 @@ import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.ArrowDownward
+import androidx.compose.material.icons.filled.CheckCircle
 import androidx.compose.material.icons.filled.ContentCopy
 import androidx.compose.material.icons.filled.Delete
 import androidx.compose.material.icons.filled.MoreVert
@@ -94,6 +95,7 @@ fun SessionDetailScreen(
 
     var menuExpanded by remember { mutableStateOf(false) }
     var showCancelDialog by remember { mutableStateOf(false) }
+    var showCompleteDialog by remember { mutableStateOf(false) }
     var showDeleteDialog by remember { mutableStateOf(false) }
     var initialLoadHandled by rememberSaveable(sessionId) { mutableStateOf(false) }
     val renderedKeys = remember(sessionId) { mutableSetOf<String>() }
@@ -170,6 +172,39 @@ fun SessionDetailScreen(
                 TextButton(
                     onClick = {
                         showCancelDialog = false
+                    },
+                ) {
+                    Text("保留")
+                }
+            },
+        )
+    }
+
+    if (showCompleteDialog) {
+        AlertDialog(
+            onDismissRequest = {
+                showCompleteDialog = false
+            },
+            title = {
+                Text("结束当前会话？")
+            },
+            text = {
+                Text("Relay 会结束当前空闲会话，结束后将无法继续对话。")
+            },
+            confirmButton = {
+                TextButton(
+                    onClick = {
+                        showCompleteDialog = false
+                        viewModel.completeSession()
+                    },
+                ) {
+                    Text("结束会话")
+                }
+            },
+            dismissButton = {
+                TextButton(
+                    onClick = {
+                        showCompleteDialog = false
                     },
                 ) {
                     Text("保留")
@@ -258,7 +293,7 @@ fun SessionDetailScreen(
                                 menuExpanded = false
                             },
                         ) {
-                            if (canSendToSession(uiState.session?.status)) {
+                            if (canCancelSession(uiState.session?.status)) {
                                 DropdownMenuItem(
                                     text = {
                                         Text("取消会话")
@@ -273,6 +308,24 @@ fun SessionDetailScreen(
                                     onClick = {
                                         menuExpanded = false
                                         showCancelDialog = true
+                                    },
+                                )
+                            }
+                            if (canCompleteSession(uiState.session?.status)) {
+                                DropdownMenuItem(
+                                    text = {
+                                        Text("结束会话")
+                                    },
+                                    leadingIcon = {
+                                        Icon(
+                                            imageVector = Icons.Filled.CheckCircle,
+                                            contentDescription = null,
+                                        )
+                                    },
+                                    enabled = !uiState.isCompleting,
+                                    onClick = {
+                                        menuExpanded = false
+                                        showCompleteDialog = true
                                     },
                                 )
                             }

--- a/packages/android/app/src/main/kotlin/com/imbot/android/ui/home/TimeUtils.kt
+++ b/packages/android/app/src/main/kotlin/com/imbot/android/ui/home/TimeUtils.kt
@@ -61,6 +61,6 @@ internal fun summarizePrompt(
     }
 }
 
-internal fun isLiveStatus(status: String): Boolean = status == "queued" || status == "running"
+internal fun isLiveStatus(status: String): Boolean = status == "queued" || status == "running" || status == "idle"
 
-internal fun isRunningStatus(status: String): Boolean = status == "running"
+internal fun isRunningStatus(status: String): Boolean = status == "running" || status == "idle"

--- a/packages/android/app/src/main/kotlin/com/imbot/android/ui/theme/Color.kt
+++ b/packages/android/app/src/main/kotlin/com/imbot/android/ui/theme/Color.kt
@@ -27,6 +27,7 @@ data class ProviderColors(
 data class StatusColors(
     val queued: Color,
     val running: Color,
+    val idle: Color,
     val completed: Color,
     val failed: Color,
     val cancelled: Color,
@@ -36,6 +37,7 @@ val LightStatusColors =
     StatusColors(
         queued = Color(0xFF9CA3AF),
         running = Color(0xFF10B981),
+        idle = Color(0xFF2196F3),
         completed = Color(0xFF059669),
         failed = Color(0xFFEF4444),
         cancelled = Color(0xFF6B7280),
@@ -45,6 +47,7 @@ val DarkStatusColors =
     StatusColors(
         queued = Color(0xFF6B7280),
         running = Color(0xFF34D399),
+        idle = Color(0xFF64B5F6),
         completed = Color(0xFF6EE7B7),
         failed = Color(0xFFFCA5A5),
         cancelled = Color(0xFF9CA3AF),
@@ -71,6 +74,7 @@ fun statusColorFor(
     when (status.lowercase()) {
         "queued" -> colors.queued
         "running" -> colors.running
+        "idle" -> colors.idle
         "completed" -> colors.completed
         "failed" -> colors.failed
         "cancelled" -> colors.cancelled

--- a/packages/android/app/src/test/kotlin/com/imbot/android/network/RelaySessionParsingTest.kt
+++ b/packages/android/app/src/test/kotlin/com/imbot/android/network/RelaySessionParsingTest.kt
@@ -38,6 +38,28 @@ class RelaySessionParsingTest {
         assertEquals("sess-2", session.getString("id"))
     }
 
+    @Test
+    fun `parses idle session status from relay payload`() {
+        val session =
+            JSONObject(
+                """
+                {
+                  "id": "sess-3",
+                  "provider": "claude",
+                  "host_id": "macbook-1",
+                  "workspace_cwd": "/tmp/demo",
+                  "status": "idle",
+                  "created_at": "2026-04-01T10:00:00Z",
+                  "updated_at": "2026-04-01T10:05:00Z",
+                  "last_active_at": "2026-04-01T10:05:00Z"
+                }
+                """.trimIndent(),
+            ).toRelaySession()
+
+        assertEquals("sess-3", session.id)
+        assertEquals("idle", session.status)
+    }
+
     @Test(expected = IllegalStateException::class)
     fun `rejects responses without a session object`() {
         JSONObject("""{"ok":true}""").requireRelaySessionObject()

--- a/packages/android/app/src/test/kotlin/com/imbot/android/ui/detail/DetailUtilsTest.kt
+++ b/packages/android/app/src/test/kotlin/com/imbot/android/ui/detail/DetailUtilsTest.kt
@@ -81,6 +81,7 @@ class DetailUtilsTest {
     @Test
     fun `status color mapping matches requirement`() {
         assertEquals(Color(0xFF10B981), detailStatusColor("running"))
+        assertEquals(Color(0xFF2196F3), detailStatusColor("idle"))
         assertEquals(Color(0xFF059669), detailStatusColor("completed"))
         assertEquals(Color(0xFFEF4444), detailStatusColor("failed"))
         assertEquals(Color(0xFF6B7280), detailStatusColor("cancelled"))
@@ -89,10 +90,32 @@ class DetailUtilsTest {
 
     @Test
     fun `input placeholder text follows session status`() {
-        assertEquals("输入消息...", inputPlaceholderForStatus("running"))
+        assertEquals("AI 正在回复...", inputPlaceholderForStatus("running"))
+        assertEquals("继续对话...", inputPlaceholderForStatus("idle"))
         assertEquals("会话已结束", inputPlaceholderForStatus("completed"))
         assertEquals("会话已失败", inputPlaceholderForStatus("failed"))
         assertEquals("会话已取消", inputPlaceholderForStatus("cancelled"))
+    }
+
+    @Test
+    fun `idle status supports follow up input while running only supports live actions`() {
+        assertTrue(canSendToSession("running"))
+        assertTrue(canSendToSession("idle"))
+        assertFalse(canSendToSession("completed"))
+
+        assertFalse(canInputToSession("running"))
+        assertTrue(canInputToSession("idle"))
+
+        assertTrue(canCancelSession("running"))
+        assertFalse(canCancelSession("idle"))
+
+        assertTrue(canCompleteSession("idle"))
+        assertFalse(canCompleteSession("running"))
+    }
+
+    @Test
+    fun `status labels include idle`() {
+        assertEquals("空闲", statusLabel("idle"))
     }
 
     @Test
@@ -104,6 +127,7 @@ class DetailUtilsTest {
         assertEquals(MessageItemKind.ToolCall, messageItemKindForEventType("tool_call_completed"))
         assertEquals(MessageItemKind.StatusChange, messageItemKindForEventType("session_status_changed"))
         assertEquals(MessageItemKind.StatusChange, messageItemKindForEventType("session_started"))
+        assertEquals(MessageItemKind.StatusChange, messageItemKindForEventType("session_idle"))
         assertEquals(MessageItemKind.StatusChange, messageItemKindForEventType("session_result"))
         assertEquals(MessageItemKind.StatusChange, messageItemKindForEventType("session_error"))
         assertEquals(MessageItemKind.StatusChange, messageItemKindForEventType("approval_required"))

--- a/packages/android/app/src/test/kotlin/com/imbot/android/ui/detail/DetailViewModelTest.kt
+++ b/packages/android/app/src/test/kotlin/com/imbot/android/ui/detail/DetailViewModelTest.kt
@@ -62,7 +62,8 @@ class DetailViewModelTest {
             assertEquals(1, relay.getSessionEventsCalls)
             assertEquals(listOf(TEST_SESSION.id), ws.subscriptions)
             assertEquals(TEST_SESSION, viewModel.uiState.value.session)
-            assertTrue(viewModel.uiState.value.canSend)
+            // running status: input disabled (waiting for Claude to finish)
+            assertFalse(viewModel.uiState.value.canSend)
         }
 
     @Test
@@ -88,6 +89,7 @@ class DetailViewModelTest {
         runTest(mainDispatcherRule.dispatcher) {
             val relay =
                 FakeRelayHttpClient().apply {
+                    getSessionResult = Result.success(TEST_SESSION.copy(status = "idle"))
                     sendMessageResult = Result.failure(IllegalStateException("发送失败"))
                 }
             val viewModel = createViewModel(relay = relay)
@@ -197,7 +199,7 @@ class DetailViewModelTest {
             advanceUntilIdle()
 
             assertEquals("running", viewModel.uiState.value.session?.status)
-            assertTrue(viewModel.uiState.value.canSend)
+            assertFalse(viewModel.uiState.value.canSend)
             assertStatusChange(viewModel.uiState.value.messages.single(), status = "running", message = null)
 
             ws.emitEvent(
@@ -239,7 +241,7 @@ class DetailViewModelTest {
             advanceUntilIdle()
 
             assertEquals("running", viewModel.uiState.value.session?.status)
-            assertTrue(viewModel.uiState.value.canSend)
+            assertFalse(viewModel.uiState.value.canSend)
             assertStatusChange(
                 viewModel.uiState.value.messages.single(),
                 status = "running",
@@ -401,6 +403,7 @@ class DetailViewModelTest {
             val gate = CompletableDeferred<Result<Unit>>()
             val relay =
                 FakeRelayHttpClient().apply {
+                    getSessionResult = Result.success(TEST_SESSION.copy(status = "idle"))
                     sendMessageHandler = { _, _, _, _ -> gate.await() }
                 }
             val viewModel = createViewModel(relay = relay)

--- a/packages/android/app/src/test/kotlin/com/imbot/android/ui/detail/EventProcessorTest.kt
+++ b/packages/android/app/src/test/kotlin/com/imbot/android/ui/detail/EventProcessorTest.kt
@@ -315,6 +315,29 @@ class EventProcessorTest {
     }
 
     @Test
+    fun `session_idle appends idle status change with follow up hint`() {
+        val result =
+            processor.process(
+                event(
+                    seq = 1,
+                    eventType = "session_idle",
+                ),
+            )
+
+        assertEquals(
+            listOf(
+                MessageItem.StatusChange(
+                    id = "id-1",
+                    status = "idle",
+                    message = "本轮完成，可继续对话",
+                    seq = 1,
+                ),
+            ),
+            result,
+        )
+    }
+
+    @Test
     fun `session_result appends status change from payload`() {
         val result =
             processor.process(

--- a/packages/android/app/src/test/kotlin/com/imbot/android/ui/home/HomeViewModelUtilsTest.kt
+++ b/packages/android/app/src/test/kotlin/com/imbot/android/ui/home/HomeViewModelUtilsTest.kt
@@ -66,6 +66,38 @@ class HomeViewModelUtilsTest {
         )
     }
 
+    @Test
+    fun `sorts idle sessions alongside running sessions ahead of completed`() {
+        val sessions =
+            listOf(
+                session(
+                    id = "idle-newest",
+                    provider = "claude",
+                    status = "idle",
+                    lastActiveAt = "2026-03-30T11:30:00Z",
+                ),
+                session(
+                    id = "running-older",
+                    provider = "book",
+                    status = "running",
+                    lastActiveAt = "2026-03-30T10:00:00Z",
+                ),
+                session(
+                    id = "completed-middle",
+                    provider = "claude",
+                    status = "completed",
+                    lastActiveAt = "2026-03-30T11:00:00Z",
+                ),
+            )
+
+        val result = applyFilterAndSort(sessions, null).map(SessionEntity::id)
+
+        assertEquals(
+            listOf("idle-newest", "running-older", "completed-middle"),
+            result,
+        )
+    }
+
     private fun session(
         id: String,
         provider: String,

--- a/packages/android/app/src/test/kotlin/com/imbot/android/ui/home/TimeUtilsTest.kt
+++ b/packages/android/app/src/test/kotlin/com/imbot/android/ui/home/TimeUtilsTest.kt
@@ -64,4 +64,10 @@ class TimeUtilsTest {
 
         assertEquals("/", summary)
     }
+
+    @Test
+    fun `idle status is treated as live and sorted with running sessions`() {
+        assertEquals(true, isLiveStatus("idle"))
+        assertEquals(true, isRunningStatus("idle"))
+    }
 }

--- a/packages/android/app/src/test/kotlin/com/imbot/android/ui/theme/ThemeResolutionTest.kt
+++ b/packages/android/app/src/test/kotlin/com/imbot/android/ui/theme/ThemeResolutionTest.kt
@@ -100,12 +100,14 @@ class ThemeResolutionTest {
     fun `status colors match foundation spec in light and dark`() {
         assertEquals(LightStatusColors.queued, statusColorFor("queued", LightStatusColors))
         assertEquals(LightStatusColors.running, statusColorFor("running", LightStatusColors))
+        assertEquals(LightStatusColors.idle, statusColorFor("idle", LightStatusColors))
         assertEquals(LightStatusColors.completed, statusColorFor("completed", LightStatusColors))
         assertEquals(LightStatusColors.failed, statusColorFor("failed", LightStatusColors))
         assertEquals(LightStatusColors.cancelled, statusColorFor("cancelled", LightStatusColors))
 
         assertEquals(DarkStatusColors.queued, statusColorFor("queued", DarkStatusColors))
         assertEquals(DarkStatusColors.running, statusColorFor("running", DarkStatusColors))
+        assertEquals(DarkStatusColors.idle, statusColorFor("idle", DarkStatusColors))
         assertEquals(DarkStatusColors.completed, statusColorFor("completed", DarkStatusColors))
         assertEquals(DarkStatusColors.failed, statusColorFor("failed", DarkStatusColors))
         assertEquals(DarkStatusColors.cancelled, statusColorFor("cancelled", DarkStatusColors))


### PR DESCRIPTION
Closes #81

## Summary
- Idle status support across Android UI: color (blue), label (空闲), input enabled
- `completeSession()` API + "结束会话" confirmation dialog
- `session_idle` event renders as turn separator
- Input enabled only in idle state; running shows "AI 正在回复..."
- Idle sessions treated as live for sort order

## Test plan
- [x] 16 files changed, idle coverage across UI/ViewModel/API/tests
- [x] Android ktlint + 234 unit tests + assembleDebug passing
- [x] Node unit + contract tests unaffected

## Agent Review

- Reviewer agents used: Correctness Reviewer, Security & UX Reviewer
- Reviewed head SHA: 482a32605959c4acbbbb009bdd8a5abdc513a065
- Review evidence: https://github.com/DankerMu/IMbot/pull/86#issuecomment-4168123759 https://github.com/DankerMu/IMbot/pull/86#issuecomment-4168123926
- Key findings addressed: All findings are by-design or standard mobile patterns (optimistic updates, idle as live status). No code changes needed.