### PR TITLE
fix(android): silence routine status bubbles in timeline

### DIFF
--- a/packages/android/app/src/main/kotlin/com/imbot/android/ui/detail/EventProcessor.kt
+++ b/packages/android/app/src/main/kotlin/com/imbot/android/ui/detail/EventProcessor.kt
@@ -80,19 +80,9 @@ class EventProcessor(
             "assistant_message" -> finalizeAssistantMessage(event)
             "tool_call_started" -> appendToolCallStarted(event)
             "tool_call_completed" -> appendToolCallCompleted(event)
-            "session_status_changed" -> appendStatusChange(event)
-            "session_started" ->
-                appendStatusChange(
-                    status = "running",
-                    message = null,
-                    seq = event.seq,
-                )
-            "session_idle" ->
-                appendStatusChange(
-                    status = "idle",
-                    message = "本轮完成，可继续对话",
-                    seq = event.seq,
-                )
+            "session_status_changed" -> appendStatusChangeIfSignificant(event)
+            "session_started" -> Unit // silent — top bar shows status
+            "session_idle" -> Unit // silent — top bar shows status
             "session_result" ->
                 appendStatusChange(
                     status = event.payload.stringValue("status").orEmpty(),
@@ -307,14 +297,24 @@ class EventProcessor(
         }
     }
 
-    private fun appendStatusChange(event: ServerMessage.Event) {
+    private fun appendStatusChangeIfSignificant(event: ServerMessage.Event) {
         val payload = event.payload ?: return
+        val status = payload.stringValue("status").orEmpty()
+        val message = payload.stringValue("message")
+        // Only show terminal states (completed/failed/cancelled) and messages
+        // indicating errors or disconnections. Routine running/idle/queued
+        // transitions are already reflected in the top-bar status indicator.
+        val isTerminal = status in terminalStatuses
+        val hasErrorMessage = !message.isNullOrBlank()
+        if (!isTerminal && !hasErrorMessage) return
         appendStatusChange(
-            status = payload.stringValue("status").orEmpty(),
-            message = payload.stringValue("message"),
+            status = status,
+            message = message,
             seq = event.seq,
         )
     }
+
+    private val terminalStatuses = setOf("completed", "failed", "cancelled")
 
     private fun appendStatusChange(
         status: String,

--- a/packages/android/app/src/test/kotlin/com/imbot/android/ui/detail/DetailViewModelTest.kt
+++ b/packages/android/app/src/test/kotlin/com/imbot/android/ui/detail/DetailViewModelTest.kt
@@ -511,7 +511,7 @@ class DetailViewModelTest {
         }
 
     @Test
-    fun `session_started and session_result update session status`() =
+    fun `session_started is silent but session_result shows terminal status`() =
         runTest(mainDispatcherRule.dispatcher) {
             val relay =
                 FakeRelayHttpClient().apply {
@@ -527,9 +527,10 @@ class DetailViewModelTest {
             ws.emitEvent(event(seq = 1, eventType = "session_started"))
             advanceUntilIdle()
 
+            // session_started updates session status but does NOT create a status bubble
             assertEquals("running", viewModel.uiState.value.session?.status)
             assertFalse(viewModel.uiState.value.canSend)
-            assertStatusChange(viewModel.uiState.value.messages.single(), status = "running", message = null)
+            assertTrue(viewModel.uiState.value.messages.isEmpty())
 
             ws.emitEvent(
                 event(
@@ -540,10 +541,10 @@ class DetailViewModelTest {
             )
             advanceUntilIdle()
 
+            // session_result is a terminal state → shows status bubble
             val messages = viewModel.uiState.value.messages
-            assertEquals(2, messages.size)
-            assertStatusChange(messages[0], status = "running", message = null)
-            assertStatusChange(messages[1], status = "completed", message = "任务完成")
+            assertEquals(1, messages.size)
+            assertStatusChange(messages[0], status = "completed", message = "任务完成")
             assertEquals("completed", viewModel.uiState.value.session?.status)
             assertFalse(viewModel.uiState.value.canSend)
         }

--- a/packages/android/app/src/test/kotlin/com/imbot/android/ui/detail/EventProcessorTest.kt
+++ b/packages/android/app/src/test/kotlin/com/imbot/android/ui/detail/EventProcessorTest.kt
@@ -368,7 +368,7 @@ class EventProcessorTest {
     }
 
     @Test
-    fun `session_started appends running status change`() {
+    fun `session_started is silent and produces no status bubble`() {
         val result =
             processor.process(
                 event(
@@ -377,21 +377,11 @@ class EventProcessorTest {
                 ),
             )
 
-        assertEquals(
-            listOf(
-                MessageItem.StatusChange(
-                    id = "id-1",
-                    status = "running",
-                    message = null,
-                    seq = 1,
-                ),
-            ),
-            result,
-        )
+        assertEquals(emptyList<MessageItem>(), result)
     }
 
     @Test
-    fun `session_idle appends idle status change with follow up hint`() {
+    fun `session_idle is silent and produces no status bubble`() {
         val result =
             processor.process(
                 event(
@@ -400,17 +390,42 @@ class EventProcessorTest {
                 ),
             )
 
-        assertEquals(
-            listOf(
-                MessageItem.StatusChange(
-                    id = "id-1",
-                    status = "idle",
-                    message = "本轮完成，可继续对话",
+        assertEquals(emptyList<MessageItem>(), result)
+    }
+
+    @Test
+    fun `session_status_changed to running is silent`() {
+        val result =
+            processor.process(
+                event(
                     seq = 1,
+                    eventType = "session_status_changed",
+                    payload = payload("status" to "running"),
                 ),
-            ),
-            result,
-        )
+            )
+
+        assertEquals(emptyList<MessageItem>(), result)
+    }
+
+    @Test
+    fun `session_status_changed with error message is shown`() {
+        val result =
+            processor.process(
+                event(
+                    seq = 1,
+                    eventType = "session_status_changed",
+                    payload =
+                        payload(
+                            "status" to "running",
+                            "message" to "Host companion disconnected unexpectedly",
+                        ),
+                ),
+            )
+
+        assertEquals(1, result.size)
+        val status = result[0] as MessageItem.StatusChange
+        assertEquals("running", status.status)
+        assertEquals("Host companion disconnected unexpectedly", status.message)
     }
 
     @Test


### PR DESCRIPTION
## Summary

Remove noisy inline status bubbles from the message timeline. Only terminal states and error messages produce bubbles now.

## Test plan

- [x] All EventProcessor + ViewModel tests updated and passing
- [x] Local detekt + ktlint + unit tests green

## Agent Review

- Reviewer agents used: Correctness Reviewer, Security & Performance Reviewer
- Reviewed head SHA: `ee30ff571f781faf8307adbc5da697844ff97231`
- Review evidence: [Review 1](https://github.com/DankerMu/IMbot/pull/101#issuecomment-4174578651) | [Review 2](https://github.com/DankerMu/IMbot/pull/101#issuecomment-4174578724)
- Key findings addressed: N/A (clean review)