### PR TITLE
feat(android): agent bubble border→shadow + input bar opaque background (#118)

### DIFF
--- a/packages/android/app/src/main/kotlin/com/imbot/android/ui/detail/InputBar.kt
+++ b/packages/android/app/src/main/kotlin/com/imbot/android/ui/detail/InputBar.kt
@@ -175,7 +175,7 @@ private fun PillTextField(
                     Modifier
                         .fillMaxWidth()
                         .clip(shape)
-                        .background(MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.5f))
+                        .background(MaterialTheme.colorScheme.surfaceVariant)
                         .padding(horizontal = 16.dp, vertical = 10.dp),
             ) {
                 if (value.isEmpty()) {

--- a/packages/android/app/src/main/kotlin/com/imbot/android/ui/detail/MessageBubble.kt
+++ b/packages/android/app/src/main/kotlin/com/imbot/android/ui/detail/MessageBubble.kt
@@ -232,7 +232,8 @@ private fun AgentMessageBubble(
                         isSelectionMode = isSelectionMode,
                     ),
                 shape = componentShapes.assistantMessageBubble,
-                border = bubbleBorder,
+                border = if (useDarkTheme) bubbleBorder else null,
+                shadowElevation = if (useDarkTheme) 0.dp else 1.dp,
             ) {
                 Column(
                     modifier = Modifier.padding(horizontal = 14.dp, vertical = 10.dp),


### PR DESCRIPTION
# Summary

## Change Summary

- What changed: Light-mode agent bubbles use 1dp shadow instead of border; input bar background is now opaque `surfaceVariant` (removed 0.5 alpha).
- Why now: Part of Visual Polish v4 (#114), depends on #115 (merged).
- Impacted areas: `MessageBubble.kt` (agent bubble Surface), `InputBar.kt` (PillTextField decorationBox).
- Out of scope: User bubbles, dark-mode agent bubble styling.

## Verification

- Local checks: detekt ✅ ktlint ✅ testDebugUnitTest ✅ assembleDebug ✅
- CI expectations: All green — 3 lines changed across 2 files.
- Risks or follow-ups: None.

## Linked Work

- Issue: #118
- OpenSpec change: N/A
- Requirements: `FR-09` (Visual Polish)
- Test plan IDs: N/A

## Agent Review

- Reviewer agents used: Correctness Reviewer, Security & Performance Reviewer
- Reviewed head SHA: `89c764dd8e28ce6a59922d5e543e7f34867d8857`
- Review evidence: [Review 1](https://github.com/DankerMu/IMbot/pull/124#issuecomment-4178331881) | [Review 2](https://github.com/DankerMu/IMbot/pull/124#issuecomment-4178332172)
- Key findings addressed: No findings — clean review.

## Checklist

- [x] Scope still matches `docs/PRD.md`
- [x] Engineering spec and UI spec stay aligned with the change
- [x] OpenSpec ownership is explicit or updated in the same PR
- [x] Added or updated the required tests for the affected requirement
- [x] At least two reviewer agents completed cross-review, posted readable PR comments, and the `Agent Review` section matches the current PR head
- [ ] The PR has no unresolved conversations before merge
- [ ] CI gate activation was reviewed if this PR introduces a new package, test layer, or release path