### PR TITLE
feat(android): refined table styles — light-mode header/border/stripes (#119)

### DIFF
--- a/packages/android/app/src/main/kotlin/com/imbot/android/ui/detail/MarkdownText.kt
+++ b/packages/android/app/src/main/kotlin/com/imbot/android/ui/detail/MarkdownText.kt
@@ -355,8 +355,9 @@ private fun MarkdownTable(
     modifier: Modifier = Modifier,
     contentColor: Color = MaterialTheme.colorScheme.onSurface,
 ) {
-    val borderColor = MaterialTheme.colorScheme.outlineVariant
-    val headerBackground = MaterialTheme.colorScheme.surfaceVariant
+    val useDarkTheme = LocalUseDarkTheme.current
+    val borderColor = if (useDarkTheme) MaterialTheme.colorScheme.outlineVariant else Color(0xFFE2E8F0)
+    val headerBackground = if (useDarkTheme) MaterialTheme.colorScheme.surfaceVariant else Color(0xFFF8FAFC)
     val columnCount = maxOf(header.size, rows.maxOfOrNull(List<String>::size) ?: 0)
 
     BoxWithConstraints(
@@ -384,6 +385,7 @@ private fun MarkdownTable(
                     alignments = alignments,
                     backgroundColor = headerBackground,
                     borderColor = borderColor,
+                    useDarkTheme = useDarkTheme,
                     textStyle =
                         MaterialTheme.typography.bodyMedium.copy(
                             fontWeight = FontWeight.Medium,
@@ -397,11 +399,16 @@ private fun MarkdownTable(
                         alignments = alignments,
                         backgroundColor =
                             if (isStripedTableRow(rowIndex)) {
-                                MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.3f)
+                                if (useDarkTheme) {
+                                    MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.3f)
+                                } else {
+                                    Color(0xFFF8FAFC)
+                                }
                             } else {
                                 MaterialTheme.colorScheme.surface
                             },
                         borderColor = borderColor,
+                        useDarkTheme = useDarkTheme,
                         textStyle = MaterialTheme.typography.bodyMedium.copy(color = contentColor),
                     )
                 }
@@ -417,6 +424,7 @@ private fun MarkdownTableRow(
     alignments: List<MarkdownTableAlignment>,
     backgroundColor: Color,
     borderColor: Color,
+    useDarkTheme: Boolean,
     textStyle: TextStyle,
 ) {
     Row(
@@ -435,7 +443,20 @@ private fun MarkdownTableRow(
                         .defaultMinSize(minWidth = MarkdownTableMinColumnWidth)
                         .fillMaxHeight()
                         .background(backgroundColor)
-                        .border(width = 1.dp, color = borderColor)
+                        .then(
+                            if (useDarkTheme) {
+                                Modifier.border(width = 1.dp, color = borderColor)
+                            } else {
+                                Modifier.drawBehind {
+                                    drawLine(
+                                        color = borderColor,
+                                        start = Offset(0f, size.height),
+                                        end = Offset(size.width, size.height),
+                                        strokeWidth = 1.dp.toPx(),
+                                    )
+                                }
+                            },
+                        )
                         .padding(
                             horizontal = MarkdownTableCellHorizontalPadding,
                             vertical = MarkdownTableCellVerticalPadding,


### PR DESCRIPTION
# Summary

## Change Summary

- What changed: Light-mode tables use `#F8FAFC` header/striped background, `#E2E8F0` border, horizontal-only cell dividers via `drawBehind`. Dark mode unchanged.
- Why now: Part of Visual Polish v4 (#114).
- Impacted areas: `MarkdownText.kt` — `MarkdownTable` + `MarkdownTableRow`.
- Out of scope: Dark-mode table styling, other markdown blocks.

## Verification

- Local checks: detekt ✅ ktlint ✅ testDebugUnitTest ✅ assembleDebug ✅
- CI expectations: All green.
- Risks or follow-ups: None.

## Linked Work

- Issue: #119
- OpenSpec change: N/A
- Requirements: `FR-09` (Visual Polish)
- Test plan IDs: N/A

## Agent Review

- Reviewer agents used: Correctness Reviewer, Security & Performance Reviewer
- Reviewed head SHA: `d6d7a8d7daf30f1c5e22c4dbf25930cfdc30ffce`
- Review evidence: [Review 1](https://github.com/DankerMu/IMbot/pull/125#issuecomment-4178394583) | [Review 2](https://github.com/DankerMu/IMbot/pull/125#issuecomment-4178394773)
- Key findings addressed: No findings — clean review.

## Checklist

- [x] Scope still matches `docs/PRD.md`
- [x] Engineering spec and UI spec stay aligned with the change
- [x] OpenSpec ownership is explicit or updated in the same PR
- [x] Added or updated the required tests for the affected requirement
- [x] At least two reviewer agents completed cross-review, posted readable PR comments, and the `Agent Review` section matches the current PR head
- [ ] The PR has no unresolved conversations before merge
- [ ] CI gate activation was reviewed if this PR introduces a new package, test layer, or release path