### PR TITLE
feat(android): InteractiveToolCard uses dedicated /answer API (#137)

### DIFF
--- a/packages/android/app/src/main/kotlin/com/imbot/android/data/repository/SessionRepository.kt
+++ b/packages/android/app/src/main/kotlin/com/imbot/android/data/repository/SessionRepository.kt
@@ -102,6 +102,26 @@ class SessionRepository
             sessionDao.deleteById(sessionId)
         }
 
+        suspend fun answerInteractiveTool(
+            sessionId: String,
+            callId: String,
+            answer: String,
+            questionIndex: Int = 0,
+        ): Result<Unit> {
+            val settings = settingsRepository.load()
+            val relayValidationError = settings.relayValidationError()
+            require(relayValidationError == null) { relayValidationError.orEmpty() }
+
+            return relayHttpClient.answerInteractiveTool(
+                relayUrl = settings.relayUrl,
+                token = settings.token,
+                sessionId = sessionId,
+                callId = callId,
+                answer = answer,
+                questionIndex = questionIndex,
+            )
+        }
+
         override suspend fun clearLocalCache() {
             database.withTransaction {
                 sessionDao.deleteAll()

--- a/packages/android/app/src/main/kotlin/com/imbot/android/network/RelayHttpClient.kt
+++ b/packages/android/app/src/main/kotlin/com/imbot/android/network/RelayHttpClient.kt
@@ -100,7 +100,7 @@ private data class RelayErrorResponse(
     val message: String,
 )
 
-@Suppress("TooManyFunctions")
+@Suppress("TooManyFunctions", "LargeClass")
 @Singleton
 open class RelayHttpClient
     @Inject
@@ -578,6 +578,47 @@ open class RelayHttpClient
                         val bodyText = response.body?.string().orEmpty()
                         if (!response.isSuccessful) {
                             throw relayFailure(response, bodyText, "Send message")
+                        }
+                    }
+                }
+            }
+
+        open suspend fun answerInteractiveTool(
+            relayUrl: String,
+            token: String,
+            sessionId: String,
+            callId: String,
+            answer: String,
+            questionIndex: Int = 0,
+        ): Result<Unit> =
+            runCatching {
+                withContext(Dispatchers.IO) {
+                    val requestBody =
+                        JSONObject()
+                            .put("call_id", callId)
+                            .put("answer", answer)
+                            .put("question_index", questionIndex)
+                            .toString()
+                            .toRequestBody(JSON_MEDIA_TYPE)
+
+                    val request =
+                        Request.Builder()
+                            .url(
+                                requireRelayBaseUrl(relayUrl)
+                                    .newBuilder()
+                                    .addPathSegments("v1/sessions")
+                                    .addPathSegment(sessionId)
+                                    .addPathSegment("answer")
+                                    .build(),
+                            )
+                            .header("Authorization", "Bearer $token")
+                            .post(requestBody)
+                            .build()
+
+                    okHttpClient.newCall(request).await().use { response ->
+                        val bodyText = response.body?.string().orEmpty()
+                        if (!response.isSuccessful) {
+                            throw relayFailure(response, bodyText, "Answer interactive tool")
                         }
                     }
                 }

--- a/packages/android/app/src/main/kotlin/com/imbot/android/ui/detail/DetailViewModel.kt
+++ b/packages/android/app/src/main/kotlin/com/imbot/android/ui/detail/DetailViewModel.kt
@@ -6,6 +6,7 @@ import androidx.lifecycle.viewModelScope
 import com.imbot.android.data.RelaySettings
 import com.imbot.android.data.SettingsRepository
 import com.imbot.android.data.relayValidationError
+import com.imbot.android.data.repository.SessionRepository
 import com.imbot.android.network.ConnectionState
 import com.imbot.android.network.RelayHttpClient
 import com.imbot.android.network.RelaySession
@@ -70,6 +71,7 @@ class DetailViewModel
     @Inject
     constructor(
         private val relayHttpClient: RelayHttpClient,
+        private val sessionRepository: SessionRepository,
         private val relayWsClient: RelayWsClient,
         private val settingsRepository: SettingsRepository,
         private val savedStateHandle: SavedStateHandle,
@@ -277,26 +279,16 @@ class DetailViewModel
             preserveWhitespace: Boolean = false,
         ) {
             val normalizedText = if (preserveWhitespace) text else text.trim()
+            val isInteractiveToolAnswer = interactiveToolCallId != null
             val state = _uiState.value
-            val canSendInput =
-                if (allowRunningInput) {
-                    canSendToSession(state.session?.status)
-                } else {
-                    state.canSend
-                }
+            val canSendInput = canSendInput(state, allowRunningInput)
 
             if (text.trim().isBlank() || state.isSending || !canSendInput) {
                 return
             }
 
-            val settings = requireValidSettings() ?: return
-            val optimisticMessage =
-                MessageItem.UserMessage(
-                    id = generateMessageItemId(),
-                    text = normalizedText,
-                    timestamp = Instant.now().toString(),
-                )
-            optimisticMessages += optimisticMessage
+            val settings = if (isInteractiveToolAnswer) null else requireValidSettings() ?: return
+            addOptimisticMessage(normalizedText, isInteractiveToolAnswer)
             interactiveToolCallId?.let { callId ->
                 interactiveAnswer?.let { answer ->
                     eventProcessor.recordInteractiveToolAnswer(callId, answer)
@@ -316,12 +308,8 @@ class DetailViewModel
             )
 
             viewModelScope.launch {
-                relayHttpClient.sendMessage(
-                    relayUrl = settings.relayUrl,
-                    token = settings.token,
-                    sessionId = sessionId,
-                    text = normalizedText,
-                ).onSuccess {
+                val result = submitSessionInputRequest(settings, interactiveToolCallId, normalizedText)
+                result.onSuccess {
                     _uiState.update { current ->
                         current.copy(
                             session =
@@ -336,7 +324,9 @@ class DetailViewModel
                     interactiveToolCallId?.let { id ->
                         eventProcessor.clearInteractiveToolAnswer(id, "发送失败，点击重试")
                     }
-                    removeOptimisticMessage(normalizedText)
+                    if (!isInteractiveToolAnswer) {
+                        removeOptimisticMessage(normalizedText)
+                    }
                     publishMessages(
                         newMessages = combinedMessages(),
                         allowAutoScroll = false,
@@ -843,6 +833,50 @@ class DetailViewModel
         }
 
         private fun combinedMessages(): List<MessageItem> = eventProcessor.snapshot() + optimisticMessages
+
+        private fun canSendInput(
+            state: DetailUiState,
+            allowRunningInput: Boolean,
+        ): Boolean =
+            if (allowRunningInput) {
+                canSendToSession(state.session?.status)
+            } else {
+                state.canSend
+            }
+
+        private fun addOptimisticMessage(
+            normalizedText: String,
+            isInteractiveToolAnswer: Boolean,
+        ) {
+            if (isInteractiveToolAnswer) {
+                return
+            }
+            optimisticMessages +=
+                MessageItem.UserMessage(
+                    id = generateMessageItemId(),
+                    text = normalizedText,
+                    timestamp = Instant.now().toString(),
+                )
+        }
+
+        private suspend fun submitSessionInputRequest(
+            settings: RelaySettings?,
+            interactiveToolCallId: String?,
+            normalizedText: String,
+        ): Result<Unit> =
+            interactiveToolCallId?.let { callId ->
+                sessionRepository.answerInteractiveTool(
+                    sessionId = sessionId,
+                    callId = callId,
+                    answer = normalizedText,
+                    questionIndex = 0,
+                )
+            } ?: relayHttpClient.sendMessage(
+                relayUrl = settings!!.relayUrl,
+                token = settings.token,
+                sessionId = sessionId,
+                text = normalizedText,
+            )
 
         private fun latestPendingInteractiveToolCallId(): String? {
             return findLatestPendingInteractiveToolCallId(_uiState.value.messages)

--- a/packages/android/app/src/test/kotlin/com/imbot/android/ui/detail/DetailViewModelTest.kt
+++ b/packages/android/app/src/test/kotlin/com/imbot/android/ui/detail/DetailViewModelTest.kt
@@ -4,9 +4,17 @@ package com.imbot.android.ui.detail
 
 import android.content.SharedPreferences
 import androidx.lifecycle.SavedStateHandle
+import androidx.room.DatabaseConfiguration
+import androidx.room.InvalidationTracker
+import androidx.sqlite.db.SupportSQLiteDatabase
+import androidx.sqlite.db.SupportSQLiteOpenHelper
 import com.imbot.android.data.ErrorStateManager
 import com.imbot.android.data.RelaySettings
 import com.imbot.android.data.SettingsRepository
+import com.imbot.android.data.local.AppDatabase
+import com.imbot.android.data.local.SessionDao
+import com.imbot.android.data.local.SessionEntity
+import com.imbot.android.data.repository.SessionRepository
 import com.imbot.android.network.ConnectionState
 import com.imbot.android.network.RelayEventPage
 import com.imbot.android.network.RelayHttpClient
@@ -132,8 +140,11 @@ class DetailViewModelTest {
             viewModel.submitToolAnswer("A")
             advanceUntilIdle()
 
-            assertEquals(1, relay.sendMessageCalls)
-            assertEquals(listOf("A"), relay.sentMessages)
+            assertEquals(0, relay.sendMessageCalls)
+            assertEquals(1, relay.answerInteractiveToolCalls)
+            assertEquals(listOf(InteractiveToolAnswerRequest(TEST_SESSION.id, "tool-1", "A", 0)), relay.interactiveToolAnswers)
+            assertEquals(1, viewModel.uiState.value.messages.size)
+            assertTrue(viewModel.uiState.value.messages.single() is MessageItem.InteractiveToolCall)
         }
 
     @Test
@@ -173,13 +184,13 @@ class DetailViewModelTest {
             viewModel.submitToolAnswer("tool-1", "A")
             advanceUntilIdle()
 
-            assertEquals(0, relay.sendMessageCalls)
+            assertEquals(0, relay.answerInteractiveToolCalls)
 
             viewModel.submitToolAnswer("tool-2", "B")
             advanceUntilIdle()
 
-            assertEquals(1, relay.sendMessageCalls)
-            assertEquals(listOf("B"), relay.sentMessages)
+            assertEquals(1, relay.answerInteractiveToolCalls)
+            assertEquals(listOf(InteractiveToolAnswerRequest(TEST_SESSION.id, "tool-2", "B", 0)), relay.interactiveToolAnswers)
         }
 
     @Test
@@ -187,7 +198,7 @@ class DetailViewModelTest {
         runTest(mainDispatcherRule.dispatcher) {
             val relay =
                 FakeRelayHttpClient().apply {
-                    sendMessageHandler = { _, _, _, _ -> Result.failure(RuntimeException("网络超时")) }
+                    answerInteractiveToolHandler = { _, _, _, _, _, _ -> Result.failure(RuntimeException("网络超时")) }
                 }
             val ws = FakeRelayWsClient()
             val viewModel = createViewModel(relay = relay, ws = ws)
@@ -216,6 +227,8 @@ class DetailViewModelTest {
             assertNull(interactive.answer)
             assertEquals("发送失败，点击重试", interactive.errorMessage)
             assertFalse(viewModel.uiState.value.isSending)
+            assertEquals(1, messages.size)
+            assertEquals(1, relay.answerInteractiveToolCalls)
         }
 
     @Test
@@ -899,13 +912,24 @@ class DetailViewModelTest {
     private fun createViewModel(
         relay: FakeRelayHttpClient = FakeRelayHttpClient(),
         ws: FakeRelayWsClient = FakeRelayWsClient(),
-    ): DetailViewModel =
-        DetailViewModel(
+    ): DetailViewModel {
+        val settingsRepository = FakeSettingsRepository()
+        val sessionDao = FakeSessionDao()
+        val sessionRepository =
+            SessionRepository(
+                database = FakeAppDatabase(sessionDao),
+                sessionDao = sessionDao,
+                relayHttpClient = relay,
+                settingsRepository = settingsRepository,
+            )
+        return DetailViewModel(
             relayHttpClient = relay,
+            sessionRepository = sessionRepository,
             relayWsClient = ws,
-            settingsRepository = FakeSettingsRepository(),
+            settingsRepository = settingsRepository,
             savedStateHandle = SavedStateHandle(mapOf("sessionId" to TEST_SESSION.id)),
         )
+    }
 }
 
 private const val TIMESTAMP = "2026-03-31T12:00:00Z"
@@ -1003,10 +1027,18 @@ private data class SessionEventsRequest(
     val limit: Int,
 )
 
+private data class InteractiveToolAnswerRequest(
+    val sessionId: String,
+    val callId: String,
+    val answer: String,
+    val questionIndex: Int,
+)
+
 private class FakeRelayHttpClient : RelayHttpClient(OkHttpClient()) {
     var getSessionResult: Result<RelaySession> = Result.success(TEST_SESSION)
     var getSessionEventsResult: Result<RelayEventPage> = Result.success(RelayEventPage(events = emptyList(), hasMore = false))
     var sendMessageResult: Result<Unit> = Result.success(Unit)
+    var answerInteractiveToolResult: Result<Unit> = Result.success(Unit)
     var resumeSessionResult: Result<RelaySession> = Result.success(TEST_SESSION.copy(status = "running"))
     var cancelSessionResult: Result<RelaySession> = Result.success(TEST_SESSION.copy(status = "cancelled"))
     var deleteSessionResult: Result<Unit> = Result.success(Unit)
@@ -1014,15 +1046,19 @@ private class FakeRelayHttpClient : RelayHttpClient(OkHttpClient()) {
     var getSessionCalls = 0
     var getSessionEventsCalls = 0
     var sendMessageCalls = 0
+    var answerInteractiveToolCalls = 0
     var resumeSessionCalls = 0
     var cancelSessionCalls = 0
     var deleteSessionCalls = 0
     val sentMessages = mutableListOf<String>()
+    val interactiveToolAnswers = mutableListOf<InteractiveToolAnswerRequest>()
 
     var getSessionHandler: suspend (String, String, String) -> Result<RelaySession> = { _, _, _ -> getSessionResult }
     var getSessionEventsHandler: suspend (String, String, String, Int, Int) -> Result<RelayEventPage> =
         { _, _, _, _, _ -> getSessionEventsResult }
     var sendMessageHandler: suspend (String, String, String, String) -> Result<Unit> = { _, _, _, _ -> sendMessageResult }
+    var answerInteractiveToolHandler: suspend (String, String, String, String, String, Int) -> Result<Unit> =
+        { _, _, _, _, _, _ -> answerInteractiveToolResult }
     var resumeSessionHandler: suspend (String, String, String) -> Result<RelaySession> = { _, _, _ -> resumeSessionResult }
     var cancelSessionHandler: suspend (String, String, String) -> Result<RelaySession> = { _, _, _ -> cancelSessionResult }
     var deleteSessionHandler: suspend (String, String, String) -> Result<Unit> = { _, _, _ -> deleteSessionResult }
@@ -1066,6 +1102,25 @@ private class FakeRelayHttpClient : RelayHttpClient(OkHttpClient()) {
         sendMessageCalls++
         sentMessages += text
         return sendMessageHandler(relayUrl, token, sessionId, text)
+    }
+
+    override suspend fun answerInteractiveTool(
+        relayUrl: String,
+        token: String,
+        sessionId: String,
+        callId: String,
+        answer: String,
+        questionIndex: Int,
+    ): Result<Unit> {
+        answerInteractiveToolCalls++
+        interactiveToolAnswers +=
+            InteractiveToolAnswerRequest(
+                sessionId = sessionId,
+                callId = callId,
+                answer = answer,
+                questionIndex = questionIndex,
+            )
+        return answerInteractiveToolHandler(relayUrl, token, sessionId, callId, answer, questionIndex)
     }
 
     override suspend fun resumeSession(
@@ -1136,6 +1191,57 @@ private class FakeSettingsRepository(
     init {
         save(initialSettings)
     }
+}
+
+private class FakeAppDatabase(
+    private val sessionDao: SessionDao,
+) : AppDatabase() {
+    override fun sessionDao(): SessionDao = sessionDao
+
+    override fun createOpenHelper(config: DatabaseConfiguration): SupportSQLiteOpenHelper =
+        object : SupportSQLiteOpenHelper {
+            override val databaseName: String = "fake-db"
+
+            override fun setWriteAheadLoggingEnabled(enabled: Boolean) = Unit
+
+            override val writableDatabase: SupportSQLiteDatabase
+                get() = error("Not used in unit tests")
+
+            override val readableDatabase: SupportSQLiteDatabase
+                get() = error("Not used in unit tests")
+
+            override fun close() = Unit
+        }
+
+    override fun createInvalidationTracker(): InvalidationTracker = InvalidationTracker(this)
+
+    override fun clearAllTables() = Unit
+}
+
+private class FakeSessionDao : SessionDao {
+    override suspend fun insertAll(sessions: List<SessionEntity>) = Unit
+
+    override fun getAll() = MutableStateFlow(emptyList<SessionEntity>())
+
+    override suspend fun getPage(
+        offset: Int,
+        limit: Int,
+    ): List<SessionEntity> = emptyList()
+
+    override fun getByPathPrefix(
+        prefix: String,
+        escapedPrefix: String,
+    ) = MutableStateFlow(emptyList<SessionEntity>())
+
+    override suspend fun getById(id: String): SessionEntity? = null
+
+    override suspend fun deleteById(id: String) = Unit
+
+    override suspend fun deleteNotIn(ids: List<String>) = Unit
+
+    override suspend fun deleteByIds(ids: List<String>) = Unit
+
+    override suspend fun deleteAll() = Unit
 }
 
 private class FakeSharedPreferences : SharedPreferences {


### PR DESCRIPTION
## Summary

- Switch interactive tool answer submission from generic `sendMessage()` to dedicated `POST /v1/sessions/:id/answer`
- Add `RelayHttpClient.answerInteractiveTool()` with `call_id`, `answer`, `question_index` fields
- Add `SessionRepository.answerInteractiveTool()` wrapper with stored config
- Refactor `DetailViewModel.sendSessionInput()` to branch on interactive tool path
- Skip optimistic user message for answer submissions (control protocol, not chat)

Closes #137

## Changes

| File | Change |
|------|--------|
| `RelayHttpClient.kt` | New `answerInteractiveTool()` → POST `/v1/sessions/:id/answer` |
| `SessionRepository.kt` | New `answerInteractiveTool()` wrapper |
| `DetailViewModel.kt` | Branch `sendSessionInput` on `interactiveToolCallId`, extract helpers |
| `DetailViewModelTest.kt` | Assert `/answer` path, no optimistic user message |

## Test plan

- [x] `./gradlew detekt ktlintMainSourceSetCheck ktlintTestSourceSetCheck ktlintAndroidTestSourceSetCheck testDebugUnitTest assembleDebug` — BUILD SUCCESSFUL
- [x] `npm run build && npm test` — all pass (no Node changes)

## Agent Review

- Reviewer agents used: Correctness Reviewer, Security & Performance Reviewer
- Reviewed head SHA: `f8968a62f87c385131b929c12ac70786d42ea76c`
- Review evidence: [Review 1](https://github.com/DankerMu/IMbot/pull/143#issuecomment-4182256223) | [Review 2](https://github.com/DankerMu/IMbot/pull/143#issuecomment-4182256677)
- Key findings addressed: No findings — both reviewers confirmed clean implementation